### PR TITLE
Update e2e test with azdo-proxy -> git-auth-proxy

### DIFF
--- a/e2e/git-auth-proxy-values.yaml
+++ b/e2e/git-auth-proxy-values.yaml
@@ -5,10 +5,13 @@ config: |
   {
     "organizations": [
       {
-        "domain": "test-nginx",
-        "scheme": "http",
         "name": "org",
-        "pat": "foobar",
+        "provider": "azuredevops",
+        "azuredevops": {
+          "pat": "foobar"
+        },
+        "host": "test-nginx",
+        "scheme": "http",
         "repositories": [
           {
             "name": "repo",


### PR DESCRIPTION
This should make the end-to-end tests pass again.