### PR TITLE
Case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ repository which is does not have access to.
 The proxy reads its configuration from a JSON file. It contains a list of repositories that can be accessed through the proxy and the Kubernetes namespaces which should receive a Secret.
 
 When using Azure DevOps a [PAT](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page) has to be
-configured for Git Auth Proxy to append to authorized requests.
+configured for Git Auth Proxy to append to authorized requests. Note that organization and repository names are matched case-insensitive.
 
 ```json
 {

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -33,7 +33,7 @@ PID=$!
 sleep 2
 TOKEN=$(kubectl -n tenant-1 get secret org-proj-repo --template={{.data.token}} | base64 -d -w 0)
 
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u username:$TOKEN http://localhost:8080/org/proj/_apis/git/repositories/repo)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -u username:$TOKEN http://localhost:8080/Org/proj/_apis/git/repositories/repo)
 if [ $STATUS != "200" ]; then
   exit 1
 fi

--- a/pkg/auth/azure_devops.go
+++ b/pkg/auth/azure_devops.go
@@ -18,15 +18,15 @@ func newAzureDevops(pat string) *azureDevops {
 }
 
 func (a *azureDevops) getPathRegex(organization, project, repository string) ([]*regexp.Regexp, error) {
-	baseApi, err := regexp.Compile(fmt.Sprintf(`/%s/_apis\b`, organization))
+	baseApi, err := regexp.Compile(fmt.Sprintf(`(?i)/%s/_apis\b`, organization))
 	if err != nil {
 		return nil, fmt.Errorf("invalid base api regex: %w", err)
 	}
-	git, err := regexp.Compile(fmt.Sprintf(`/%s/%s/_git/%s(/.*)?\b`, organization, project, repository))
+	git, err := regexp.Compile(fmt.Sprintf(`(?i)/%s/%s/_git/%s(/.*)?\b`, organization, project, repository))
 	if err != nil {
 		return nil, err
 	}
-	api, err := regexp.Compile(fmt.Sprintf(`/%s/%s/_apis/git/repositories/%s(/.*)?\b`, organization, project, repository))
+	api, err := regexp.Compile(fmt.Sprintf(`(?i)/%s/%s/_apis/git/repositories/%s(/.*)?\b`, organization, project, repository))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/azure_devops_test.go
+++ b/pkg/auth/azure_devops_test.go
@@ -48,6 +48,15 @@ func TestAzureDevOpsPermitted(t *testing.T) {
 	require.NoError(t, err, "token should be permitted")
 }
 
+func TestAzureDevOpsPermittedCaseInsensitive(t *testing.T) {
+	authz := getAzureDevOpsAuthorizer()
+	endpoint, err := authz.GetEndpointById("foo-org-proj-repo")
+	require.NoError(t, err)
+	path := "/Org/proJ/_git/repo"
+	err = authz.IsPermitted(path, endpoint.Token)
+	require.NoError(t, err, "token should be permitted")
+}
+
 func TestAzureDevOpsPermittedExtraPath(t *testing.T) {
 	authz := getAzureDevOpsAuthorizer()
 	endpoint, err := authz.GetEndpointById("foo-org-proj-repo")

--- a/pkg/auth/github.go
+++ b/pkg/auth/github.go
@@ -30,11 +30,11 @@ func newGithub(appID, installationID int64, privateKey []byte) (*github, error) 
 }
 
 func (g *github) getPathRegex(organization, project, repository string) ([]*regexp.Regexp, error) {
-	git, err := regexp.Compile(fmt.Sprintf(`/%s/%s(/.*)?\b`, organization, repository))
+	git, err := regexp.Compile(fmt.Sprintf(`(?i)/%s/%s(/.*)?\b`, organization, repository))
 	if err != nil {
 		return nil, err
 	}
-	api, err := regexp.Compile(fmt.Sprintf(`/api/v3/(.*)/%s/%s/(/.*)?\b`, organization, repository))
+	api, err := regexp.Compile(fmt.Sprintf(`(?i)/api/v3/(.*)/%s/%s/(/.*)?\b`, organization, repository))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/github_test.go
+++ b/pkg/auth/github_test.go
@@ -62,6 +62,11 @@ func TestGitHubAuthorization(t *testing.T) {
 			allow: true,
 		},
 		{
+			name:  "allow repo",
+			path:  "/Org/repO",
+			allow: true,
+		},
+		{
 			name:  "allow api",
 			path:  "/api/v3/org/repo",
 			allow: true,


### PR DESCRIPTION
Users may use upper-case letters in org or repo names when creating accounts or repos without realizing that these values go into URLs which are typically matched case-sensitive as per RFC 3986.
