### PR TITLE
Increase ReadTimeout for Gin server

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: 1.19
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
           version: v1.46.2
   test:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.46.2
+          version: v1.51.2
   test:
     runs-on: ubuntu-latest
     steps:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,7 +23,7 @@ func NewServer(logger logr.Logger, addr string, authz *auth.Authorizer) *Server 
 	router.GET("/readyz", readinessHandler)
 	router.GET("/healthz", livenessHandler)
 	router.NoRoute(proxyHandler(authz))
-	srv := &http.Server{ReadTimeout: 5 * time.Second, Addr: addr, Handler: router}
+	srv := &http.Server{ReadTimeout: 30 * time.Second, Addr: addr, Handler: router}
 	return &Server{
 		srv: srv,
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,7 +23,9 @@ func NewServer(logger logr.Logger, addr string, authz *auth.Authorizer) *Server 
 	router.GET("/readyz", readinessHandler)
 	router.GET("/healthz", livenessHandler)
 	router.NoRoute(proxyHandler(authz))
-	srv := &http.Server{ReadTimeout: 30 * time.Second, Addr: addr, Handler: router}
+	// The ReadTimeout is set to 5 min make sure that strange requests don't live forever
+	// But in general the external request should set a good timeout value for it's request.
+	srv := &http.Server{ReadTimeout: 5 * time.Minute, Addr: addr, Handler: router}
 	return &Server{
 		srv: srv,
 	}


### PR DESCRIPTION
This to be able to support larger git repos that takes more then 5s to clone